### PR TITLE
Integrate agent tools into session configuration

### DIFF
--- a/websocket-server/src/agents/index.ts
+++ b/websocket-server/src/agents/index.ts
@@ -4,3 +4,4 @@ export const agents = [sarahAgent];
 export const tools = agents.flatMap((agent) => agent.tools);
 
 export { sarahAgent };
+export default sarahAgent;

--- a/websocket-server/src/functionHandlers.ts
+++ b/websocket-server/src/functionHandlers.ts
@@ -1,20 +1,25 @@
 import { FunctionHandler } from "./types";
 import { tools } from "./agents";
-import { FunctionTool } from "@openai/agents";
 
-const functionTools = tools.filter((t): t is FunctionTool => t.type === "function");
+const functions: FunctionHandler[] = [];
 
-const functions: FunctionHandler[] = functionTools.map((t) => ({
-  schema: {
-    name: t.name,
-    type: "function",
-    description: t.description,
-    parameters: t.parameters as any,
-  },
-  handler: async (args: any) => {
-    const result = await t.invoke(undefined as any, JSON.stringify(args));
-    return typeof result === "string" ? result : JSON.stringify(result);
-  },
-}));
+tools.forEach((tool: any) => {
+  const schema =
+    tool.schema || {
+      name: tool.name,
+      type: "function",
+      description: tool.description,
+      parameters: tool.parameters as any,
+    };
+
+  const handler =
+    tool.execute ||
+    (async (args: any) => {
+      const result = await tool.invoke(undefined as any, JSON.stringify(args));
+      return typeof result === "string" ? result : JSON.stringify(result);
+    });
+
+  functions.push({ schema, handler });
+});
 
 export default functions;

--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -1,5 +1,6 @@
 import { RawData, WebSocket } from "ws";
 import functions from "./functionHandlers";
+import agent from "./agents";
 
 interface Session {
   twilioConn?: WebSocket;
@@ -137,10 +138,12 @@ function tryConnectModel() {
       session: {
         modalities: ["text", "audio"],
         turn_detection: { type: "server_vad" },
-        voice: "ash",
         input_audio_transcription: { model: "whisper-1" },
         input_audio_format: "g711_ulaw",
         output_audio_format: "g711_ulaw",
+        instructions: agent.instructions,
+        voice: agent.voice,
+        tools: agent.tools.map((t: any) => t.schema),
         ...config,
       },
     });

--- a/websocket-server/src/types.ts
+++ b/websocket-server/src/types.ts
@@ -27,5 +27,5 @@ export interface FunctionSchema {
 
 export interface FunctionHandler {
   schema: FunctionSchema;
-  handler: (args: any) => Promise<string>;
+  handler: (args: any) => Promise<any>;
 }


### PR DESCRIPTION
## Summary
- Load default agent and include its voice, instructions, and tool schemas in realtime session setup
- Register agent tools as function handlers so model function calls resolve to the correct implementations
- Broaden function handler type definitions to accommodate tool outputs

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68906a18638c832cae995a5baaee33e8