### PR TITLE
Initialize session with default config on websocket connect

### DIFF
--- a/webapp/components/call-interface.tsx
+++ b/webapp/components/call-interface.tsx
@@ -10,6 +10,12 @@ import { Item } from "@/components/types";
 import handleRealtimeEvent from "@/lib/handle-realtime-event";
 import PhoneNumberChecklist from "@/components/phone-number-checklist";
 
+const DEFAULT_AGENT_CONFIG = {
+  instructions: "You are a helpful assistant in a phone call.",
+  voice: "ash",
+  tools: [] as any[],
+};
+
 const CallInterface = () => {
   const [selectedPhoneNumber, setSelectedPhoneNumber] = useState("");
   const [allConfigsReady, setAllConfigsReady] = useState(false);
@@ -24,6 +30,13 @@ const CallInterface = () => {
       newWs.onopen = () => {
         console.log("Connected to logs websocket");
         setCallStatus("connected");
+
+        const updateEvent = {
+          type: "session.update",
+          session: DEFAULT_AGENT_CONFIG,
+        };
+        console.log("Sending initial session.update:", updateEvent);
+        newWs.send(JSON.stringify(updateEvent));
       };
 
       newWs.onmessage = (event) => {

--- a/websocket-server/src/sessionManager.ts
+++ b/websocket-server/src/sessionManager.ts
@@ -113,6 +113,7 @@ function handleFrontendMessage(data: RawData) {
 
   if (msg.type === "session.update") {
     session.saved_config = msg.session;
+    tryConnectModel();
   }
 }
 


### PR DESCRIPTION
## Summary
- Send an initial `session.update` with default voice/instructions when the frontend websocket connects.
- Trigger model initialization on the server whenever a `session.update` is received.

## Testing
- `npm test` (webapp) *(fails: Missing script)*
- `npm run build` (webapp)
- `npm test` (websocket-server) *(fails: no test specified)*
- `npm run build` (websocket-server)


------
https://chatgpt.com/codex/tasks/task_e_689112973b68832cbb01e33e58ac938e