### PR TITLE
Sync session config with Sarah agent defaults

### DIFF
--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -11,6 +11,7 @@ import {
   handleFrontendConnection,
 } from "./sessionManager";
 import functions from "./functionHandlers";
+import agent from "./agents";
 
 dotenv.config();
 
@@ -49,6 +50,13 @@ app.all("/twiml", (req, res) => {
 // New endpoint to list available tools (schemas)
 app.get("/tools", (req, res) => {
   res.json(functions.map((f) => f.schema));
+});
+
+app.get("/session", (req, res) => {
+  res.json({
+    instructions: agent.instructions,
+    voice: agent.voice,
+  });
 });
 
 let currentCall: WebSocket | null = null;


### PR DESCRIPTION
## Summary
- default session configuration panel to Sarah's instructions and voice
- fetch initial agent configuration from new `/session` backend endpoint

## Testing
- `npm test` (webapp) *(fails: Missing script)*
- `npm run lint` (webapp) *(cannot run: interactive ESLint setup prompt)*
- `npm run build` (webapp) *(hangs while creating production build)*
- `npm test` (websocket-server) *(fails: no test specified)*
- `npm run build` (websocket-server)


------
https://chatgpt.com/codex/tasks/task_e_6891191d5ea8832cab23656db47e02ba